### PR TITLE
Correct `alhorithm` and `{en,de}cript` typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ target_wrapper.*
 # QtCreator CMake
 CMakeLists.txt.user*
 
-# QtCreator 4.8< compilation database 
+# QtCreator 4.8< compilation database
 compile_commands.json
 
 # QtCreator local machine specific files for imported projects

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,19 @@
-# Contributing in to EeasySSL 
+# Contributing in to EasySSL
 
 This is a wrap library for the Qt developers. So if you think that is a good library, and you use it in your projects - you can add new improvements and create a pull request with new features.
 
-## What can you do for this Library ? 
+## What can you do for this Library ?
 
-1. You can add a support of new encryption algorithms 
+1. You can add a support of new encryption algorithms.
 2. You can implement new certificate generator.
 
 ## Adding new implementation of crypto algorithms
 
-All Algorithms must be pass simple test. Encrypt, decrypt short and long data arrays. This simple test already implemented, and you just need to add it into main test file. 
+All algorithms must pass simple test. Encrypt, decrypt short and long data arrays. This simple test is already implemented, and you just need to add it into the main test file.
 
 ### Example
 
-Adding supporting RSA algorithm to this library. 
+Adding supporting RSA algorithm to this library.
 
 1. Create implementation of the iCrypto interface.
 
@@ -25,7 +25,7 @@ Adding supporting RSA algorithm to this library.
      * @brief The RSASSL class This is wrapper for RSA algorithm of openssl 3.0 libraryry.
      */
     class EASYSSL_EXPORT RSASSL: public EasySSL::ICrypto {
-  
+
       // override main methods of the interface.
       EVP_PKEY *makeRawKeys() const override;
       Features supportedFeatures() const override;
@@ -34,36 +34,35 @@ Adding supporting RSA algorithm to this library.
       bool checkSign(const QByteArray &inputData, const QByteArray &signature, const QByteArray &key) const override;
       QByteArray decrypt(const QByteArray &message, const QByteArray &key) override;
       QByteArray encrypt(const QByteArray &message, const QByteArray &key) override;
-  
+
     }
    ```
-   
+
 Full implementation of the RSA you can see [here](https://github.com/QuasarApp/easyssl/blob/main/src/lib/src/public/easyssl/rsassl.h).
 
 2. Add your class to the tests Using The Template class [CryptoTest](https://github.com/QuasarApp/easyssl/blob/main/tests/units/cryptotest.h). See The [tstMain.cpp](https://github.com/QuasarApp/easyssl/blob/main/tests/tstMain.cpp) file
 
 ```cpp
-
-    TestCase(cryptoTestRSA, CryptoTest<EasySSL::RSASSL>)
+TestCase(cryptoTestRSA, CryptoTest<EasySSL::RSASSL>)
 ```
 
-## Adding new implementation of Certificate generator. 
+## Adding new implementation of Certificate generator.
 
 1. Create implementation of the iCrypto interface. And override the create method.
 
 ```cpp
-  /**
-   * @brief The X509 class This is wrapper of the ssl objects.
-   */
-  class EASYSSL_EXPORT X509: public  EasySSL::ICertificate
-  {
-  public:
-      X509(const QSharedPointer<ICrypto>& generator);
-  
-      // ICertificate interface
-  public:
-      SelfSignedSertificate create(const SslSrtData& certificateData) const override;
-  };
+/**
+ * @brief The X509 class This is wrapper of the ssl objects.
+ */
+class EASYSSL_EXPORT X509: public  EasySSL::ICertificate
+{
+public:
+    X509(const QSharedPointer<ICrypto>& generator);
+
+    // ICertificate interface
+public:
+    SelfSignedSertificate create(const SslSrtData& certificateData) const override;
+};
 ```
 
 Full implementation of x509 certificate format you can see [here](https://github.com/QuasarApp/easyssl/blob/main/src/lib/src/public/easyssl/x509.h).
@@ -71,18 +70,17 @@ Full implementation of x509 certificate format you can see [here](https://github
 2. Add your class to the tests Using The Template class [CrtTest](https://github.com/QuasarApp/easyssl/blob/main/tests/units/crttest.h). See The [tstMain.cpp](https://github.com/QuasarApp/easyssl/blob/main/tests/tstMain.cpp) file
 
 ```cpp
-  #include "crttest.h"
+#include "crttest.h"
 
-  using CrtTestX509ECDSA = CrtTest<EasySSL::X509, EasySSL::ECDSASSL>;
-  TestCase(crtTestX509ECDSA, CrtTestX509ECDSA)
-
+using CrtTestX509ECDSA = CrtTest<EasySSL::X509, EasySSL::ECDSASSL>;
+TestCase(crtTestX509ECDSA, CrtTestX509ECDSA)
 ```
 
 ## Extra rools
 
 1. All shared tools or useful functions located on the [EasySSLUtils](https://github.com/QuasarApp/easyssl/blob/main/src/lib/src/private/easysslutils.h) class.
-2. All implementation must contains goxygen xml comments (documentation)
+2. All implementation must contain doxygen xml comments (documentation)
 3. All implementation must be inner EasySSL name space.
 
-# Thank you  
+# Thank you
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This library contains interfaces for the signing and encryption data.
 ## Build and Include
 
  * cd yourRepo
- * git submodule add https://github.com/QuasarApp/easyssl.git # add the repository of Heart into your repo like submodule
+ * git submodule add https://github.com/QuasarApp/easyssl.git # add the repository of EasySSL into your repo like submodule
  * git submodule update --init --recursive
  * Include in your CMakeLists.txt file the main CMakeLists.txt file of Heart library
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # EasySSL
-This is wrapper library that make using OpenSSL library more simple. 
+This is wrapper library that make using OpenSSL library more simple.
 This library contains interfaces for the signing and encryption data.
 
 ### Supported encryption algorithms:
@@ -14,16 +14,16 @@ This library contains interfaces for the signing and encryption data.
 
 
 ## Build and Include
- 
+
  * cd yourRepo
  * git submodule add https://github.com/QuasarApp/easyssl.git # add the repository of Heart into your repo like submodule
  * git submodule update --init --recursive
  * Include in your CMakeLists.txt file the main CMakeLists.txt file of Heart library
- 
+
      ```cmake
      add_subdirectory(easyssl)
      ```
-     
+
  * link the Heart library to your target
      ```cmake
      target_link_libraries(yourLib PUBLIC easyssl)
@@ -44,10 +44,10 @@ int main() {
     QByteArray pub, priv;
     EasySSL::RSASSL crypto;
     crypto.makeKeys(pub, priv)
-    
+
     auto siganture = crypto.signMessage(message, priv);
     crypto.checkSign(message, siganture, pub);
-    
+
     auto encryptedMsg = crypto.encrypt(message, pub);
     auto decryptedMsg = crypto.decrypt(encryptedMsg, priv);
 }
@@ -56,7 +56,7 @@ int main() {
 ```
 
 
-### Authentication 
+### Authentication
 
 ```cpp
 #include <easyssl/authecdsa.h>
@@ -96,7 +96,7 @@ edsa.auth(1000, &userID)
 
 ```
 
-## Do not forget to help us make this library better... 
-See our main documentation about contributing to [EasySsl](https://github.com/QuasarApp/easyssl/blob/main/CONTRIBUTING.md) 
+## Do not forget to help us make this library better...
+See our main documentation about contributing to [EasySsl](https://github.com/QuasarApp/easyssl/blob/main/CONTRIBUTING.md)
 
-Full documentation available [here](https://quasarapp.ddns.net:3031/docs/QuasarApp/easyssl/latest/index.html) 
+Full documentation available [here](https://quasarapp.ddns.net:3031/docs/QuasarApp/easyssl/latest/index.html)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # EasySSL
 This is wrapper library that make using OpenSSL library more simple. 
-This library contains interfaces for the signing and encription data.
+This library contains interfaces for the signing and encryption data.
 
-### Supported encription alhorithms:
+### Supported encryption algorithms:
 * ECDSA
 * RSA
 
 ### Supported features
-* encription 
+* encryption
 * signing
 * keys creating
-* asyn auth bse on the asyn encriptions methods
+* asyn auth bse on the asyn encryptions methods
 
 
 ## Build and Include
@@ -34,7 +34,7 @@ This library contains interfaces for the signing and encription data.
 
 ## Usage
 
-### Encription
+### Encryption
 
 ```cpp
 #include "easyssl/rsassl.h"
@@ -48,8 +48,8 @@ int main() {
     auto siganture = crypto.signMessage(message, priv);
     crypto.checkSign(message, siganture, pub);
     
-    auto encriptedMsg = crypto.encrypt(message, pub);
-    auto decryptedMsg = crypto.decrypt(encriptedMsg, priv);
+    auto encryptedMsg = crypto.encrypt(message, pub);
+    auto decryptedMsg = crypto.decrypt(encryptedMsg, priv);
 }
 
 

--- a/src/lib/src/public/easyssl/asynckeysauth.h
+++ b/src/lib/src/public/easyssl/asynckeysauth.h
@@ -18,8 +18,8 @@ namespace EasySSL {
 
 /**
  * @brief The AsyncKeysAuth class is temaplate class for works with authorization of a pair of asynchronous keys
- *  This class contains base implementation for the authentication using async encription. The base encription alhorithm defined on the template argument **CryptoImplementation**.
- *  You can use any crypto alhorithm.
+ *  This class contains base implementation for the authentication using async encryption. The base encryption algorithm defined on the template argument **CryptoImplementation**.
+ *  You can use any crypto algorithm.
  *
  *  ## Exampel of use:
  *
@@ -60,7 +60,7 @@ namespace EasySSL {
  * * After accept server create new user with ID = sha256(PUB) or
  * if user alredy exits make them as a logined user.
  *
- * @tparam CryptoImplementation This is internal implementaion of base encription functions.
+ * @tparam CryptoImplementation This is internal implementaion of base encryption functions.
  * @see iCrypto class.
  *
  */

--- a/src/lib/src/public/easyssl/icrypto.h
+++ b/src/lib/src/public/easyssl/icrypto.h
@@ -29,8 +29,8 @@ public:
     enum Features {
         /// Signin and check sign of the data.
         Signing = 0x01,
-        /// Encription and decription data
-        Encription = 0x02
+        /// Encryption and decryption data
+        Encryption = 0x02
     };
 
     /**
@@ -48,34 +48,34 @@ public:
     virtual QSsl::KeyAlgorithm keyAlgorithm() const = 0;
 
     /**
-     * @brief supportedFeatures This method should return supported featurs of the current encription alhorithm
+     * @brief supportedFeatures This method should return supported featurs of the current encryption algorithm
      * @return Features list.
      * @see Features
      */
     virtual Features supportedFeatures() const = 0;
 
     /**
-     * @brief decrypt This method decript @a message using @a key.
-     * @param message This is encripted message that should be decripted.
-     * @param key This is key that will be used for decription for the @a message.
-     * @return decripted message or empty string if method not supported or decripted failed.
-     * @see IAsyncEncription::encript
+     * @brief decrypt This method decrypt @a message using @a key.
+     * @param message This is encrypted message that should be decrypted.
+     * @param key This is key that will be used for decryption for the @a message.
+     * @return decrypted message or empty string if method not supported or decrypted failed.
+     * @see IAsyncEncryption::encrypt
      */
     virtual QByteArray decrypt(const QByteArray& message, const QByteArray& key) = 0;
 
     /**
-     * @brief encrypt This method encript @a message using @a key.
-     * @param message This is a message that should be decripted.
-     * @param key This is key that will be used for encription for the @a message.
-     * @return decripted message or empty string if method not supported or decripted failed.
-     * @see IAsyncEncription::encript
+     * @brief encrypt This method encrypt @a message using @a key.
+     * @param message This is a message that should be decrypted.
+     * @param key This is key that will be used for encryption for the @a message.
+     * @return decrypted message or empty string if method not supported or decrypted failed.
+     * @see IAsyncEncryption::encrypt
      */
     virtual QByteArray encrypt(const QByteArray& message, const QByteArray& key) = 0;
 
     /**
      * @brief signMessage This method should be sign the @a message using the @a key.
      * @param message This is input data that should be signed.
-     * @param key This is a privete key for encription the @a message.
+     * @param key This is a privete key for encryption the @a message.
      * @return signature data array.
      * @see AsyncKeysAuth::descrupt
      */
@@ -83,10 +83,10 @@ public:
 
     /**
      * @brief checkSign This method should be check signature of the @a message using the @a key.
-     * @param message This is input data that should be decripted.
+     * @param message This is input data that should be decrypted.
      * @param signature This is signature that will be checked for the @a message.
-     * @param key This is a public key for encription the @a inpputData.
-     * @return decripted data array.
+     * @param key This is a public key for encryption the @a inpputData.
+     * @return decrypted data array.
      * @see AsyncKeysAuth::encrypt
      */
     virtual bool checkSign(const QByteArray& message,

--- a/src/lib/src/public/easyssl/rsassl.cpp
+++ b/src/lib/src/public/easyssl/rsassl.cpp
@@ -38,7 +38,7 @@ void *RSASSL::makeRawKeys() const {
 }
 
 ICrypto::Features RSASSL::supportedFeatures() const {
-    return static_cast<ICrypto::Features>(Features::Encription | Features::Signing);
+    return static_cast<ICrypto::Features>(Features::Encryption | Features::Signing);
 }
 
 QSsl::KeyAlgorithm RSASSL::keyAlgorithm() const {
@@ -147,7 +147,7 @@ QByteArray RSASSL::decrypt(const QByteArray &message, const QByteArray &key) {
 
     const long long maxDencryptedSize = EVP_PKEY_size(rsaPrivateKey);
     if (message.length() % maxDencryptedSize) {
-        qCritical() << "Error wrong encripted data size.";
+        qCritical() << "Error wrong encrypted data size.";
         qCritical() << "Your key requir size multiple " << maxDencryptedSize;
 
         return {};

--- a/src/lib/src/public/easyssl/rsassl.cpp
+++ b/src/lib/src/public/easyssl/rsassl.cpp
@@ -139,7 +139,7 @@ QByteArray RSASSL::decrypt(const QByteArray &message, const QByteArray &key) {
     auto rsaPrivateKey = PEM_read_bio_PrivateKey(pkey, nullptr, nullptr, nullptr);
     BIO_free(pkey);
 
-    if (!rsaPrivateKey) {        
+    if (!rsaPrivateKey) {
         qCritical() << "Error reading private key";
         EasySSLUtils::printlastOpenSSlError();
         return {};
@@ -164,7 +164,7 @@ QByteArray RSASSL::decrypt(const QByteArray &message, const QByteArray &key) {
         EasySSLUtils::printlastOpenSSlError();
 
         EVP_PKEY_CTX_free(ctx);
-        EVP_PKEY_free(rsaPrivateKey);        
+        EVP_PKEY_free(rsaPrivateKey);
         return {};
     }
 

--- a/src/lib/src/public/easyssl/rsassl.h
+++ b/src/lib/src/public/easyssl/rsassl.h
@@ -67,12 +67,12 @@ public:
 
     /**
      * @brief padding This is mode of pending data before icnription.
-     * @return encription pending mode.
+     * @return encryption pending mode.
      */
     RSAPadding padding() const;
 
     /**
-     * @brief setPadding This method sets new mode for encription pendong.
+     * @brief setPadding This method sets new mode for encryption pendong.
      * @param newPadding This is new new mode.
      * @note You must change padding mode for both side (encryption and decryption)
     */

--- a/tests/units/cryptotest.h
+++ b/tests/units/cryptotest.h
@@ -50,10 +50,10 @@ public:
             QVERIFY2(crypto.checkSign(message, siganture, pub), "failed to check message");
         }
 
-        if (crypto.supportedFeatures() & EasySSL::ICrypto::Features::Encription) {
-            auto encriptedMsg = crypto.encrypt(message, pub);
-            QVERIFY2(encriptedMsg.size(), "Encripted message should not be empty");
-            auto decryptedMsg = crypto.decrypt(encriptedMsg, priv);
+        if (crypto.supportedFeatures() & EasySSL::ICrypto::Features::Encryption) {
+            auto encryptedMsg = crypto.encrypt(message, pub);
+            QVERIFY2(encryptedMsg.size(), "Encrypted message should not be empty");
+            auto decryptedMsg = crypto.decrypt(encryptedMsg, priv);
             QVERIFY2(decryptedMsg == message, "Failed to check message after decryption");
         }
     }


### PR DESCRIPTION
Also note the typo in [the repository *About*](https://github.com/QuasarApp/easyssl):

> This is Qt wrap**p**er of the ssl library.